### PR TITLE
Test job failing in pipeline

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -35,6 +35,10 @@ jobs:
         # A valid semver specifier of the just version to install
         just-version: 0.10.5 # optional
 
+    - name: Install Minisat
+      run: |
+        apt install minisat
+
     - name: Install dependencies
       run: |
         just install --with=dev

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -37,7 +37,7 @@ jobs:
 
     - name: Install Minisat
       run: |
-        apt install minisat
+        sudo apt install -y minisat
 
     - name: Install dependencies
       run: |


### PR DESCRIPTION
Test job is failing because I forgot to add minisat to be installed on
the Ubuntu runner.

This can be fixed (as long as adding minisat installation to the
pipeline doesn't severely show it down).