### PR TITLE
CICD pipeline broken

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -41,7 +41,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        just install --with=dev
+        just install
 
     - name: Lint with flake8
       run: |

--- a/README.md
+++ b/README.md
@@ -1,0 +1,69 @@
+**A Python package for working with Conjunctive Normal Form (CNFs) and Boolean Satisfiability (SAT)**
+
+<a href="https://img.shields.io/github/license/vaibhavkarve/normal-form?style=flat-square"> <img src="https://img.shields.io/github/license/vaibhavkarve/normal-form?style=flat-square" alt="License"> </a>
+<a href="https://img.shields.io/badge/Python-v3.10-blue?style=flat-square"> <img src="https://img.shields.io/badge/Python-v3.10-blue?style=flat-square" alt="Python:v3.10"> </a>
+
+This Python package is brought to you by [Vaibhav Karve](https://vaibhavkarve.github.io) and [Anil N. Hirani](https://faculty.math.illinois.edu/~hirani/), Department of Mathematics, University of Illinois at Urbana-Champaign.
+
+`normal-form` recognizes variables, literals, clauses, and CNFs. The package implements an interface to easily construct CNFs and SAT-check them via third-part libraries [MINISAT](http://minisat.se/) and [PySAT](https://pysathq.github.io/).
+
+This package is written in Python v3.10, and is publicly available under the [GNU-GPL-v3.0 license](https://github.com/vaibhavkarve/normal-form/blob/main/LICENSE). It is set to be released on the [Python Packaging Index](https://pypi.org/) as an open-source scientific package written in the literate programming style. We specifically chose to write this package as a literate program, despite the verbosity of this style, with the goal to create reproducible computational research.
+
+
+# Installation and usage
+
+To get started on using this package,
+
+1.  Istall Python 3.10 or higher.
+2.  `python3.10 -m pip install normal-form`
+3.  Use it in a python script (or interactive REPL) as &#x2013;
+    
+    ```python
+    from normal_form import cnf
+    from normal_form import sat
+    
+    # This is the CNF (a ∨ b ∨ ¬c) ∧ (¬b ∨ c ∨ ¬d) ∧ (¬a ∨ d).
+    x1: cnf.Cnf = cnf.cnf([[1, 2, -3], [-2, 3, -4], [-1, 4]])
+    
+    sat_x1: bool = sat.cnf_bruteforce_satcheck(x1)
+    print(sat_x1)  # prints: True because x1 is satisfiable.
+    ```
+
+
+# Overview of modules
+
+The package consists of the following modules.
+
+| **Modules that act on Cnfs**      |                                                                                     |
+| [`cnf.py`](cnf)                   | Constructors and functions for sentences in conjunctive normal form                 |
+| [`cnf_simplify.py`](cnf_simplify) | Functions for simplifying Cnfs, for example (a∨b∨c) ∧ (a∨b∨&not; c) ⇝ (a ∨ b)       |
+| [`prop.py`](prop)                 | Functions for propositional calculus &#x2013; conjunction, disjunction and negation |
+| **Modules concerning SAT**        |                                                                                     |
+| [`sat.py`](sat)                   | Functions for sat-checking Cnfs                                                     |
+| [`sxpr.py`](sxpr)                 | Functions for working with s-expressions                                            |
+| **Test suite**                    |                                                                                     |
+| `tests/*`                         | Unit- and property-based tests for each module                                      |
+
+
+# Algorithms
+
+Currently, `normal-form` implements the following algorithms &#x2013;
+
+-   For formulae in conjunctive normal forms (CNFs), it implements variables, literals, clauses, Boolean formulae, and truth-assignments. It includes an API for reading, parsing and defining new instances.
+
+-   For satisfiability of CNFs, it contains a bruteforce algorithm, an implementation that uses the open-source sat-solver [PySAT](https://pysathq.github.io/), and an implementation using the [MiniSAT](http://minisat.se/) solver.
+
+
+# Principles
+
+`normal-form` has been written in the functional-programming style with the following principles in mind &#x2013;
+
+-   Avoid classes as much as possible. Prefer defining functions instead.
+
+-   Write small functions and then compose/map/filter them to create more complex functions.
+
+-   Use lazy evaluation strategy whenever possible (using the [itertools](https://docs.python.org/3/library/itertools.html) library).
+
+-   Add type hints wherever possible (checked using the [mypy](https://mypy.readthedocs.io/en/stable/) static type-checker).
+
+-   Add unit-tests for each function (checked using the [pytest](https://docs.pytest.org/en/latest/) framework). Further, add property-based testing wherever possible (using the [hypothesis](https://hypothesis.readthedocs.io) framework).

--- a/justfile
+++ b/justfile
@@ -90,7 +90,6 @@ org2py:
 
 # Create website docs and serve on localhost.
 docs:
-    # README.org -> README.md conversion should be done in org by (auto-org-md-mode).
     org-weave -E emacs README.org > README.md
     just _write_md
     -poetry run mkdocs serve

--- a/justfile
+++ b/justfile
@@ -21,11 +21,9 @@ check-py:
     # Make sure you are using Python >= 3.10
 
 # Install all pip requirements for "normal_form" project.
-install dependencies="":
+install:
     python3 -m pip install --upgrade pip
-    python3 -m pip install poetry
-    poetry install {{dependencies}}
-    # poetry run nbstripout --install
+    poetry install
     # Consider running "just test" for testing the project.
 
 # Update dependendencies (for package devs only).
@@ -35,15 +33,15 @@ update:
 
 # Lint and check the codebase for style.
 lint:
-    poetry run autoflake --in-place --recursive --expand-star-imports --remove-all-unused-imports normal_form/* tests/*
-    poetry run isort normal_form/ tests/
+    poetry run autoflake --in-place --recursive --expand-star-imports --remove-all-unused-imports normal_form/*
+    poetry run isort normal_form/
     # stop the build if there are Python syntax errors or undefined names
     poetry run flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
     # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
     poetry run flake8 . --count --exit-zero --max-complexity=10 --max-line-length=95 --statistics
-    -poetry run pylint -vvv normal_form/ tests/
-    -poetry run pycodestyle --max-line-length=95 normal_form/ tests/
-    -poetry run pydocstyle normal_form/ tests/
+    -poetry run pylint -vvv normal_form/
+    -poetry run pycodestyle --max-line-length=95 normal_form/
+    -poetry run pydocstyle normal_form/
 
 # Typecheck the code using mypy.
 typecheck files="":
@@ -93,6 +91,7 @@ org2py:
 # Create website docs and serve on localhost.
 docs:
     # README.org -> README.md conversion should be done in org by (auto-org-md-mode).
+    org-weave -E emacs README.org > README.md
     just _write_md
     -poetry run mkdocs serve
 

--- a/justfile
+++ b/justfile
@@ -112,12 +112,23 @@ _write_md:
       echo "::: normal_form.$base" >> docs/$base".md"
     done
 
-# Push package to PyPI.
-pypi:
-	@poetry publish \
-	--username={{ env_var("PYPI_USERNAME") }} \
-	--password={{ env_var("PYPI_PASSWORD") }} \
-	--build --verbose
+# Bump package version, tag on git, and push package to PyPI.
+pypi type="patch":
+    # Check if pyroject.toml has already been modified.
+    git diff --exit-code pyproject.toml && exit
+    # Bump package version in pyproject.toml.
+    poetry version {{ type }}
+    # Commit the pyproject.toml file.
+    git add pyproject.toml
+    git commit -m "bump package version"
+    # Create lightweight git tag.
+    git tag `poetry version --short`
+    git push origin `poetry version --short`
+    # Publish to PyPI.
+    @poetry publish \
+    --username={{ env_var("PYPI_USERNAME") }} \
+    --password={{ env_var("PYPI_PASSWORD") }} \
+    --build --verbose
 
 export_md:
 	emacsclient -e ''

--- a/normal_form/sxpr.py
+++ b/normal_form/sxpr.py
@@ -12,7 +12,6 @@ from typing import Callable, Generic, Tuple, TypeVar
 from colorama import Fore, Style
 from loguru import logger
 
-
 # Type variables and aliases
 Src = TypeVar('Src', covariant=True)
 Trgt = TypeVar('Trgt', covariant=True)

--- a/normal_form/tests/test_cnf.py
+++ b/normal_form/tests/test_cnf.py
@@ -64,7 +64,7 @@ def test_lit_class(instance: Bool | int, other: Bool | int) -> None:
         # Here we silence mypy for the sake of testing that `Lit.value` is frozen.
 
 
-@given(st.from_type(Bool | int))  # type: ignore  # Mypy errors on union type.
+@given(st.from_type(Bool | int))  # type: ignore[arg-type]  # Mypy errors on union type.
 def test_lit_on_int_and_bool_input(instance: Bool | int) -> None:
     pytest.raises(ValueError, lit, 0)
     pytest.raises(TypeError, lit, "T")

--- a/normal_form/tests/test_sxpr.py
+++ b/normal_form/tests/test_sxpr.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python3.8
 
 import operator as op
+
 from normal_form.cnf import Cnf
 from normal_form.sxpr import AtomicSxpr, SatSxpr, Sxpr
 


### PR DESCRIPTION
Primary cause seems to be that the installation job (i.e. the
pyproject.toml file) refers to README.md file. This file however has
not been added to the repository.